### PR TITLE
Improve `ipstools_cfg.py`

### DIFF
--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -9,6 +9,7 @@
 DEFAULT_SERVER = "https://github.com"
 
 IPSTOOLS_DIR = 'ipstools'
+IPSTOOLS_COMMIT = '16db053f44f632b37198325ba339f9ebda14efa3'
 
 #################################
 ## DO NOT EDIT BELOW THIS LINE ##
@@ -41,7 +42,7 @@ def execute_out(cmd, silent=False):
 # Strip trailing slashes from `DEFAULT_SERVER`.
 DEFAULT_SERVER = DEFAULT_SERVER.rstrip('/')
 
-# Download latest IPApproX tools into `./IPSTOOLS_DIR` and import them.
+# Update IPApproX tools in `./IPSTOOLS_DIR` to specified commit and import them.
 if not os.path.exists(IPSTOOLS_DIR):
     delim = ':' if '@' in DEFAULT_SERVER else '/'
     execute("git clone {}{}pulp-platform/IPApproX {}".format(DEFAULT_SERVER, delim, IPSTOOLS_DIR))
@@ -49,6 +50,7 @@ elif not os.path.isdir(IPSTOOLS_DIR):
     sys.exit("Error: '{}' exists but is not a directory!".format(IPSTOOLS_DIR))
 cwd = os.getcwd()
 os.chdir(IPSTOOLS_DIR)
-execute("git pull", silent=True)
+execute("git fetch --all", silent=True)
+execute("git checkout {}".format(IPSTOOLS_COMMIT))
 os.chdir(cwd)
 import ipstools

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -28,7 +28,7 @@ def execute(cmd, silent=False):
         stdout = None
     ret = subprocess.call(cmd.split(), stdout=stdout)
     if silent:
-        devnull.close()  
+        devnull.close()
     return ret
 
 def execute_out(cmd, silent=False):

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -36,6 +36,9 @@ def execute_out(cmd, silent=False):
     out, err = p.communicate()
     return out
 
+# Strip trailing slashes from `DEFAULT_SERVER`.
+DEFAULT_SERVER = DEFAULT_SERVER.rstrip('/')
+
 # download latest IPApproX tools in ./ipstools and import them
 if os.path.exists("ipstools") and os.path.isdir("ipstools"):
     cwd = os.getcwd()

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -8,6 +8,8 @@
 # and you want to push things there
 DEFAULT_SERVER = "https://github.com"
 
+IPSTOOLS_DIR = 'ipstools'
+
 #################################
 ## DO NOT EDIT BELOW THIS LINE ##
 #################################
@@ -40,12 +42,13 @@ def execute_out(cmd, silent=False):
 DEFAULT_SERVER = DEFAULT_SERVER.rstrip('/')
 
 # Download latest IPApproX tools into `./IPSTOOLS_DIR` and import them.
-if os.path.exists(IPSTOOLS_DIR) and os.path.isdir(IPSTOOLS_DIR):
-    cwd = os.getcwd()
-    os.chdir(IPSTOOLS_DIR)
-    execute("git pull", silent=True)
-    os.chdir(cwd)
-else:
+if not os.path.exists(IPSTOOLS_DIR):
     delim = ':' if '@' in DEFAULT_SERVER else '/'
     execute("git clone {}{}pulp-platform/IPApproX {}".format(DEFAULT_SERVER, delim, IPSTOOLS_DIR))
+elif not os.path.isdir(IPSTOOLS_DIR):
+    sys.exit("Error: '{}' exists but is not a directory!".format(IPSTOOLS_DIR))
+cwd = os.getcwd()
+os.chdir(IPSTOOLS_DIR)
+execute("git pull", silent=True)
+os.chdir(cwd)
 import ipstools

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -45,8 +45,7 @@ if os.path.exists("ipstools") and os.path.isdir("ipstools"):
     os.chdir("ipstools")
     execute("git pull", silent=True)
     os.chdir(cwd)
-    import ipstools
 else:
     delim = ':' if '@' in DEFAULT_SERVER else '/'
     execute("git clone {}{}pulp-platform/IPApproX ipstools".format(DEFAULT_SERVER, delim))
-    import ipstools
+import ipstools

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -39,13 +39,13 @@ def execute_out(cmd, silent=False):
 # Strip trailing slashes from `DEFAULT_SERVER`.
 DEFAULT_SERVER = DEFAULT_SERVER.rstrip('/')
 
-# download latest IPApproX tools in ./ipstools and import them
-if os.path.exists("ipstools") and os.path.isdir("ipstools"):
+# Download latest IPApproX tools into `./IPSTOOLS_DIR` and import them.
+if os.path.exists(IPSTOOLS_DIR) and os.path.isdir(IPSTOOLS_DIR):
     cwd = os.getcwd()
-    os.chdir("ipstools")
+    os.chdir(IPSTOOLS_DIR)
     execute("git pull", silent=True)
     os.chdir(cwd)
 else:
     delim = ':' if '@' in DEFAULT_SERVER else '/'
-    execute("git clone {}{}pulp-platform/IPApproX ipstools".format(DEFAULT_SERVER, delim))
+    execute("git clone {}{}pulp-platform/IPApproX {}".format(DEFAULT_SERVER, delim, IPSTOOLS_DIR))
 import ipstools

--- a/ipstools_cfg.py
+++ b/ipstools_cfg.py
@@ -47,5 +47,6 @@ if os.path.exists("ipstools") and os.path.isdir("ipstools"):
     os.chdir(cwd)
     import ipstools
 else:
-    execute("git clone https://github.com/pulp-platform/IPApproX ipstools")
+    delim = ':' if '@' in DEFAULT_SERVER else '/'
+    execute("git clone {}{}pulp-platform/IPApproX ipstools".format(DEFAULT_SERVER, delim))
     import ipstools


### PR DESCRIPTION
After [#5](https://github.com/pulp-platform/IPApproX/pull/5) is merged, IPApproX will support `git://` remotes. This PR allows to also clone IPApproX via `git://`, respecting `DEFAULT_SERVER`. Additionally, this PR allows to pin the version of IPApproX (via `IPSTOOLS_COMMIT`) for fully reproducible checkouts. `IPSTOOLS_COMMIT` is set to the commit currently at the head of master (after [#5](https://github.com/pulp-platform/IPApproX/pull/5) had been merged).